### PR TITLE
Fix log message in server main

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	ser := server.NewHttpServer(":8080")
-	log.Println("Stating http server @", ser.Addr)
+    log.Println("Starting http server @", ser.Addr)
 	err := ser.ListenAndServe()
 	if err != nil {
 		log.Fatal("Unable to start server!")


### PR DESCRIPTION
## Summary
- fix a typo in the HTTP server startup message

## Testing
- `go build ./...`
